### PR TITLE
Text on main website

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,20 @@ but we should have a rough plan for how links stay working.
 
 ## Active URIs
 
-* <https://ariel-os.org/>, <https://www.ariel-os.org/>
+* <https://ariel-os.org/>
 
-  (on the long run, we may pick the former as the canonical and redirect the other there)
+  Running a website, following a URI style with trailing slashes and thus no technology specific file names.
 
-  redirect to <https://github.com/ariel-os/ariel-os>
+  We care about most paths (initlally, `/`, `/imprint/`, `/blog/` and `/blog/*/`),
+  and plan to issue redirects should we later decide on a different structure.
+
+  We do not care about long-term stability of included resources:
+  `/fonts/`, `/css/`, `/favicons{.*,/}`;
+  in fact, some of those use deliberately ephemeral names to combat cache mismatches.
+
+* <https://www.ariel-os.org/>
+
+  Pure redirect to ariel-os.org for those whose fingers can't let go of that habit.
 
 * <https://crab.ariel-os.org/>
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ but we should have a rough plan for how links stay working.
 
   Running a website, following a URI style with trailing slashes and thus no technology specific file names.
 
-  We care about most paths (initlally, `/`, `/imprint/`, `/blog/` and `/blog/*/`),
+  We care about most paths (initially, `/`, `/imprint/`, `/blog/` and `/blog/*/`),
   and plan to issue redirects should we later decide on a different structure.
 
   We do not care about long-term stability of included resources:


### PR DESCRIPTION
Proposed long-term stability handling of https://ariel-os.org/ URIs.

Open questions:
* [ ] Can we include images (as in figures, not as in visual elements) in the longterm plans? (I think so, but then, how do we tell them apart?)
* [x] What about the present but non-linked paths `/index.xml` (nice but I'd rather have it as `/blog/` with media type selection, or `/blog/feed/`), `/tags/` and `/categories/`?

    Addressed in https://github.com/ariel-os/ariel-os.github.io/pull/14
* [ ] Do we want to fix some paths before we commit to anything by advertising the website? Like, put the date in blog posts? Have a technology independent path for the RSS feed? Maybe even use conventions from elsewhere and clearly designate internal service paths as `/_css/` etc? (Would go well with [removing](https://github.com/ariel-os/ariel-os.github.io/pull/10) the hard-pathed `/favicon.ico`).
* [ ] <del>When we flip the switch to github.com, let's either update the statement about having http→https redirects everywhere, or just click the box in GitHub.</del> [edit: moot as we're not going to GitHub]